### PR TITLE
Fix handling of load where :staged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next
 
-* Next feature description here 
+* Fixed handling of loads where :staged, which could cause an incorrect underlying query using a "staged" column.
 
 ## 3.1
 

--- a/lib/praxis-mapper/identity_map.rb
+++ b/lib/praxis-mapper/identity_map.rb
@@ -113,7 +113,10 @@ module Praxis::Mapper
       query_class = @connection_manager.repository(model.repository_name)[:query]
       query = query_class.new(self, model, &block)
 
-      return finalize_model!(model, query) if query.where == :staged
+      if query.where == :staged
+        query.where = nil
+        return finalize_model!(model, query)
+      end
 
       records = query.execute
       add_records(records)

--- a/spec/praxis-mapper/identity_map_spec.rb
+++ b/spec/praxis-mapper/identity_map_spec.rb
@@ -108,6 +108,25 @@ describe Praxis::Mapper::IdentityMap do
 
     end
 
+    context 'where :staged' do
+      after do
+        identity_map.load AddressModel do
+          where :staged
+          track :foobar
+        end
+      end
+      it 'calls finalize_model!' do
+        identity_map.should_receive(:finalize_model!).with(AddressModel, anything())
+      end
+      it 'removes the :staged from the query where clause' do
+        identity_map.should_receive(:finalize_model!) do |model, query|
+          model.should be(AddressModel)
+          query.where.should be(nil)
+          query.track.should eq(Set.new([:foobar])) 
+        end
+      end
+    end
+
     context 'with a query with a subload' do
       context 'for a many_to_one association' do
         before do


### PR DESCRIPTION
- Delete the :staged clause in the query right before doing finalize

Fixes #7 

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
