### PR TITLE
Support `many_to_many` without `:through` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fix selector generator to properly handle composite key associations.
 * Fix `default_selection` in `Query::Base` to accountt for models with composite identities.
+* Support `many_to_many` relationships without requiring the `:through` annotations (for ORMs that
+  can transparently load the intermediate relationships)
 
 ## 4.3
 

--- a/spec/praxis-mapper/selector_generator_spec.rb
+++ b/spec/praxis-mapper/selector_generator_spec.rb
@@ -76,6 +76,27 @@ describe Praxis::Mapper::SelectorGenerator do
       end
     end
 
+    context 'that is many_to_many without a :through option' do
+      let(:properties) { {other_commented_posts: { id: true} } }
+      let(:resource) { UserResource }
+      let(:expected_selectors) do
+        {
+          PostModel => {
+            select: Set.new([:id]),
+            track: Set.new([])
+          },
+          UserModel => {
+            select: Set.new([]),
+            track: Set.new([:other_commented_posts])
+          }
+        }
+      end
+      it 'generates the correct set of selectors' do
+        generator.selectors.should eq expected_selectors
+      end
+    end
+
+
     context 'that uses a composite key' do
       let(:properties) { {composite_model: {id: true, type: true} } }
       let(:resource) { OtherResource }

--- a/spec/support/spec_sequel_models.rb
+++ b/spec/support/spec_sequel_models.rb
@@ -89,6 +89,10 @@ class UserModel < Sequel::Model(:users)
     join_table: 'comments', join_model: 'CommentModel',
     through: [:comments, :post]
 
+  many_to_many :other_commented_posts, class: 'PostModel',
+    left_key: :author_id, right_key: :post_id,
+    join_table: 'comments', join_model: 'CommentModel' #Explicitly not specify the :through option
+
   many_to_one :main_blog, class: 'BlogModel', key: :main_blog_id
 end
 


### PR DESCRIPTION
Allow a `many_to_many` mapper relationship to not require the `:through`
parameter to annotate the intermediate relationships.

ORMs like Sequel, for example, will be in charge of performing the joins
and requiring to have select fields modified for these intermediate tables.
Therefore there is no need to track them (or select specific fields from them).

This was basically a feature required for the PraxisMapper-native ORM, which
needs to know all the joins/fields of all actual tables.