### PR TITLE
Allow wrapping objects that act as arrays but are not Enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # praxis-mapper changelog
 
+## next 
+
+* Support wrapping associations in resources for targets that do not explicitly contain the `Enumerable` module. For example,  `ActiveRecord::Associations::CollectionProxy` are actually not enumerable, yet they proxy the calls directly to the underlying objects when necessary.
+
 ## 4.4.1 (6/25/2019)
 
 * Fix `Resource` to not override association methods already defined 

--- a/lib/praxis-mapper/resource.rb
+++ b/lib/praxis-mapper/resource.rb
@@ -145,11 +145,12 @@ module Praxis::Mapper
 
 
     def self.wrap(records)
-      case records
-      when nil
+      if records.nil?
         return []
-      when Enumerable
-        return records.compact.collect { |record| self.for_record(record) }
+      elsif( records.is_a?(Enumerable) )
+        return records.compact.map { |record| self.for_record(record) }
+      elsif ( records.respond_to?(:to_a) )
+        return records.to_a.compact.map { |record| self.for_record(record) }
       else
         return self.for_record(records)
       end

--- a/spec/praxis-mapper/resource_spec.rb
+++ b/spec/praxis-mapper/resource_spec.rb
@@ -200,6 +200,14 @@ describe Praxis::Mapper::Resource do
       wrapped_set.should be_kind_of(Array)
       wrapped_set.length.should be(1)
     end
+    
+    it 'works with non-enumerable objects, that respond to collect' do
+      collectable = double("ArrayProxy")
+      collectable.stub(:to_a) { [record, record] }
+
+      wrapped_set = SimpleResource.wrap(collectable)
+      wrapped_set.length.should be(2)
+    end
 
     it 'works regardless of the resource class used' do
       SimpleResource.wrap(record).should be(OtherResource.wrap(record))


### PR DESCRIPTION
There are things such as `ActiveRecord::Associations::CollectionProxy` that are actually not enumerable, yet they proxy the calls directly to the underlying objects when necessary. This commit allows the mapper to properly wrap them by checking if they support `.map`.